### PR TITLE
test: add tests for nested structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde_redis"
-version = "0.29.0"
+version = "0.3.0"
 authors = [
     "Joe Wilm <joe@jwilm.com>",
     "b00f (@b00f)"
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/serde-redis"
 edition = "2024"
 
 [dependencies]
-redis = "0.29"
+redis = "0.30"
 serde = "1.0"
 
 [dev-dependencies]

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -459,6 +459,37 @@ fn deserialize_pipelined_single_hmap_newtype_fields() {
     assert_eq!(expected, actual);
 }
 
+#[test]
+fn deserialize_nested_structs() {
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Fruit {
+        name: String,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Basket {
+        fruit: Fruit,
+    }
+    let values = Value::Array(vec![
+        Value::BulkString(b"fruit".to_vec()),
+        Value::Array(vec![
+            Value::BulkString(b"name".to_vec()),
+            Value::BulkString(b"apple".to_vec()),
+        ]),
+    ]);
+
+    let de = Deserializer::new(&values);
+    let actual: Basket = Deserialize::deserialize(de).unwrap();
+
+    let expected = Basket {
+        fruit: Fruit {
+            name: "apple".to_string(),
+        },
+    };
+
+    assert_eq!(expected, actual);
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Details {
     pub time: i64,

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -308,6 +308,37 @@ fn serialize_pipelined_single_hmap_newtype_fields() {
     assert_eq!(expected, actual);
 }
 
+#[test]
+fn serialize_nested_structs() {
+    #[derive(Debug, Serialize, PartialEq)]
+    struct Fruit {
+        name: String,
+    }
+
+    #[derive(Debug, Serialize, PartialEq)]
+    struct Basket {
+        fruit: Fruit,
+    }
+
+    let b = Basket {
+        fruit: Fruit {
+            name: "apple".to_string(),
+        },
+    };
+
+    let actual = b.serialize(Serializer).unwrap();
+
+    let expected = Value::Array(vec![
+        Value::BulkString(b"fruit".to_vec()),
+        Value::Array(vec![
+            Value::BulkString(b"name".to_vec()),
+            Value::BulkString(b"apple".to_vec()),
+        ]),
+    ]);
+
+    assert_eq!(expected, actual);
+}
+
 #[derive(Debug, Serialize)]
 pub struct Details {
     pub time: i64,


### PR DESCRIPTION
This PR adds tests for nested structs and update `redis` version.
