### PR TITLE
chore: upgrade redis

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/serde-redis"
 edition = "2024"
 
 [dependencies]
-redis = "0.29"
+redis = "0.31"
 serde = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
as mentioned in the PR's comment https://github.com/ezex-io/ezex-core/pull/15#discussion_r2085907590, we need to bump redis version so building on ezex-core can pass